### PR TITLE
Detect ProcMon in a more generic way

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8...3.0)
 
 project ( antianalysis_demos )
 
@@ -10,6 +10,7 @@ set (hdrs
 	classic_antivm.h
 	neutrino_checks.h
 	kernelmode_antidbg.h
+	procmon_check.h
 )
 
 set (srcs
@@ -18,8 +19,10 @@ set (srcs
 	classic_antivm.cpp
 	neutrino_checks.cpp
 	kernelmode_antidbg.cpp
+	procmon_check.cpp
 )
 
 add_executable ( ${PROJECT_NAME} ${exe_hdrs} ${srcs} main.cpp )
+target_link_libraries ( antianalysis_demos fltlib.lib )
 
 INSTALL( TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX} COMPONENT ${PROJECT_NAME} )

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@
 #include "classic_antivm.h"
 #include "neutrino_checks.h"
 #include "kernelmode_antidbg.h"
+#include "procmon_check.h"
 
 //#define SINGLE_STEPPING_CHECK
 
@@ -52,6 +53,10 @@ int main()
     if (kdb_mode == KDB_LOCAL_ENABLED || kdb_mode == KDB_REMOTE_ENABLED) {
         is_detected = true;
         std::cout << "[*] Kernelmode debugging enabled!\n";
+    }
+    if (is_procmon_sc_present()) {
+        is_detected = true;
+        std::cout << "[*] ProcMon service is present!\n";
     }
     if (is_detected) {
         MessageBoxA(NULL, "Analysis environment detected!", "Detected", MB_ICONEXCLAMATION | MB_OK);

--- a/procmon_check.cpp
+++ b/procmon_check.cpp
@@ -1,0 +1,58 @@
+#include "procmon_check.h"
+#include <fltuser.h>
+
+static NTSTATUS is_procmon_sc_registered(const wchar_t* service_name, const size_t service_name_size);
+
+static HRESULT tryopen_procmon_sc(const wchar_t* service_name);
+
+static BOOL do_is_procmon_present(const wchar_t* service_name, const size_t service_name_size);
+
+static NTSTATUS is_procmon_sc_registered(const wchar_t* service_name, const size_t service_name_size) {
+    HKEY hk;
+    wchar_t w_subkey[1024] = L"";
+    wcsncpy_s(w_subkey, sizeof(w_subkey) / sizeof(w_subkey[0])  - 2, L"System\\CurrentControlSet\\Services\\",
+              wcslen(L"System\\CurrentControlSet\\Services\\"));
+    wcsncat_s(w_subkey, sizeof(w_subkey) / sizeof(w_subkey[0]) - 2, service_name, service_name_size);
+    NTSTATUS retval = RegOpenKeyExW(HKEY_LOCAL_MACHINE, w_subkey, 0, KEY_QUERY_VALUE, &hk);
+    if (retval == ERROR_SUCCESS) {
+        RegCloseKey(hk);
+    }
+    return retval;
+}
+
+static HRESULT tryopen_procmon_sc(const wchar_t* service_name) {
+    HFILTER filter;
+    HRESULT res = FilterCreate(service_name, &filter);
+    if (res == S_OK) {
+        FilterClose(filter);
+    }
+    return res;
+}
+
+static BOOL do_is_procmon_present(const wchar_t* service_name, const size_t service_name_size) {
+    HRESULT res = tryopen_procmon_sc(service_name);
+    switch (res) {
+        case S_OK:
+            return TRUE;
+
+        case E_ACCESSDENIED:
+            return (is_procmon_sc_registered(service_name, service_name_size) == ERROR_SUCCESS);
+    }
+    return FALSE;
+}
+
+BOOL is_procmon_sc_present(void) {
+    static const wchar_t* procmon_scs[] = {
+        L"PROCMON24",
+        L"PROCMON23",
+    };
+    static const size_t procmon_scs_nr = sizeof(procmon_scs) / sizeof(procmon_scs[0]);
+    const wchar_t** service = &procmon_scs[0];
+    const wchar_t** service_end = service + procmon_scs_nr;
+    BOOL is = FALSE;
+    while (!is && service != service_end) {
+        is = do_is_procmon_present(*service, wcslen(*service));
+        service++;
+    }
+    return is;
+}

--- a/procmon_check.h
+++ b/procmon_check.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <windows.h>
+
+BOOL is_procmon_sc_present(void);


### PR DESCRIPTION
Hi!

I have added some code to detect procmon presence by probing its minifilter services (PROCMON23/PROCMON24). Maybe you find interesting of adding it into the repo upstream.

The detection routine tries to connect to this minifilter by using FilterCreate(), if connected (having a window or not) it will warning. Since those services are about a non-stopable service, when FilterCreate() has failed due to access denied issues, the service registry keys will be probed, having one of them it will warning. The nice part is that probing registry keys do not require admin privileges (even not having a procmon instance currently active it points that the environment is not trustworthy for the process, so better to warning, too).

ProcMon messes the machine's registry by letting some info of its service installed permanently from the first execution in the system, I believe that it is a side-effect caused by the lack of a DriverUnload routine on its device drivers, anyway, it makes easy the detection.

I also fixed the warning displayed by cmake. It was claiming about the indication of a minimum version that will be deprecated soon.